### PR TITLE
Pass in sensor values by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ahrs-rs
 
-[![creates.io](http://meritbadge.herokuapp.com/ahrs)](https://crates.io/crates/ahrs)
+[![crates.io](http://meritbadge.herokuapp.com/ahrs)](https://crates.io/crates/ahrs)
 [![Build Status](https://travis-ci.org/jmagnuson/ahrs-rs.svg?branch=master)](https://travis-ci.org/jmagnuson/ahrs-rs)
 
 A Rust port of Sebastian Madgwick's [AHRS algorithm](http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/).
@@ -37,7 +37,7 @@ fn main() {
     let magnetometer = Vector3::new(0.5, 0.6, 0.7);
     
     // Run inputs through AHRS filter (gyroscope must be radians/s)
-    ahrs.update(gyroscope * (f64::consts::PI/180.0), accelerometer, magnetometer);
+    ahrs.update( &(gyroscope * (f64::consts::PI/180.0)), &accelerometer, &magnetometer);
     
     // Do something with the updated state quaternion
     println!("{}", ahrs.quat);
@@ -45,8 +45,9 @@ fn main() {
 
 ```
 
-Crate [nalgebra](https://crates.io/crate/nalgeebra) is also needed as a dependency for its algebraic types `Vector3` and `Quaternion`.
+Crate [nalgebra](https://crates.io/crate/nalgebra) is also needed as a dependency for its algebraic types `Vector3` and `Quaternion`.
 
 ## License
 
 GPLv3
+

--- a/benches/ahrs.rs
+++ b/benches/ahrs.rs
@@ -41,14 +41,14 @@ macro_rules! _bench_ahrs2(
     // iterations is 1
     ($b: ident, $t: ident, $op: ident, 1, $( $x: expr ),* ) => {
         let mut ahrs = $t::default();
-        $b.iter(|| ahrs.$op( $($x),* ));
+        $b.iter(|| ahrs.$op( &$($x),* ));
     };
     // iterations is $n, and $x is expanded based on input from `_bench_ahrs1` operation
     ($b: ident, $t: ident, $op: ident, $n: expr, $( $x: expr ),* )  => {
         $b.iter(|| {
           let mut ahrs = $t::default();
           for n in 0..$n {
-              ahrs.$op( $( $x[n] ),* );
+              ahrs.$op( $( &$x[n] ),* );
           }
         })
     };

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -6,10 +6,10 @@ pub trait Ahrs<N: BaseFloat> {
 
   /// Updates the current state quaternion using 9dof IMU values, made up by `gyroscope`,
   /// `accelerometer`, and `magnetometer`.
-  fn update( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N>, magnetometer: Vector3<N> ) -> bool;
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool;
 
   /// Updates the current state quaternion using 6dof IMU values, made up by `gyroscope` &
   /// `accelerometer`.
-  fn update_imu( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N> ) -> bool;
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool;
 }
 

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -97,7 +97,7 @@ impl<N: BaseFloat> Madgwick<N> {
 
 impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
 
-  fn update( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N>, magnetometer: Vector3<N> ) -> bool {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool {
     let q = self.quat;
     
     let zero: N = na::zero();
@@ -106,13 +106,13 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     let half: N = na::cast(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(&accelerometer, zero) {
+    let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
         None => { return false; }
     };
     
     // Normalize magnetometer measurement
-    let mag = match try_normalize(&magnetometer, zero) {
+    let mag = match try_normalize(magnetometer, zero) {
         Some(n) => n,
         None => { return false; }
     };
@@ -142,7 +142,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     let step = na::normalize(&(J_t * F));
 
     // Compute rate of change for quaternion
-    let qDot = q * Quaternion::from_parts(zero, gyroscope)
+    let qDot = q * Quaternion::from_parts(zero, *gyroscope)
         * half - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
 
     // Integrate to yield quaternion
@@ -151,7 +151,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     true
   }
 
-  fn update_imu( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N> ) -> bool {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool {
     let q = self.quat;
 
     let zero: N = na::zero();
@@ -160,7 +160,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     let half: N = na::cast(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(&accelerometer, zero) {
+    let accel = match try_normalize(accelerometer, zero) {
       Some(n) => n,
       None => { return false; }
     };
@@ -179,7 +179,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     let step = na::normalize(&(J_t * F));
 
     // Compute rate of change of quaternion
-    let qDot = (q * Quaternion::from_parts(zero, gyroscope))
+    let qDot = (q * Quaternion::from_parts(zero, *gyroscope))
         * half - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
 
     // Integrate to yield quaternion

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -110,7 +110,7 @@ impl<N: BaseFloat> Mahony<N> {
 }
 impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
 
-  fn update( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N>, magnetometer: Vector3<N> ) -> bool {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool {
 
     let q = self.quat;
     
@@ -119,13 +119,13 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     let half: N = na::cast(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(&accelerometer, zero) {
+    let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
         None => { return false; }
     };
     
     // Normalize magnetometer measurement
-    let mag = match try_normalize(&magnetometer, zero) {
+    let mag = match try_normalize(magnetometer, zero) {
         Some(n) => n,
         None => { return false; }
     };
@@ -155,7 +155,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     }
     
     // Apply feedback terms
-    let gyro = gyroscope + e * self.kp + self.e_int * self.ki;
+    let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
 
     // Compute rate of change of quaternion
     let qDot = q * Quaternion::from_parts(zero, gyro) * half;
@@ -166,7 +166,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     true
   }
 
-  fn update_imu( &mut self, gyroscope: Vector3<N>, accelerometer: Vector3<N> ) -> bool {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool {
 
     let q = self.quat;
     
@@ -175,7 +175,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     let half: N = na::cast(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(&accelerometer, zero) {
+    let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
         None => { return false; }
     };
@@ -196,7 +196,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     }
 
     // Apply feedback terms
-    let gyro = gyroscope + e * self.kp + self.e_int * self.ki;
+    let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
 
     // Compute rate of change of quaternion
     let qDot = q * Quaternion::from_parts(zero, gyro) * half;

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -20,7 +20,7 @@ extern crate ahrs;
     let gyro = na::one();
     let mag = na::one();
 
-    let res = ahrs.update(gyro, accel, mag);
+    let res = ahrs.update(&gyro, &accel, &mag);
 
     let fail_message = "Normalizing zero-value accel should have failed.";
 
@@ -37,7 +37,7 @@ extern crate ahrs;
     let gyro = na::one();
     let mag = na::zero();
 
-    let res = ahrs.update(gyro, accel, mag);
+    let res = ahrs.update(&gyro, &accel, &mag);
 
     let fail_message = "Normalizing zero-value mag should have failed.";
 
@@ -53,7 +53,7 @@ extern crate ahrs;
     let accel = na::zero();
     let gyro = na::one();
 
-    let res = ahrs.update_imu(gyro, accel);
+    let res = ahrs.update_imu(&gyro, &accel);
 
     let fail_message = "Normalizing zero-value accel should have failed.";
 
@@ -75,7 +75,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(gyro * (f64::consts::PI/180.0), accel, mag);
+    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag);
 
     let expected = Quaternion::new( 0.7235467139148768,
                                     0.6888611247479446,
@@ -103,7 +103,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(gyro * (f64::consts::PI/180.0), accel);
+    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel);
 
     let expected = Quaternion::new( 0.7190919791549198,
                                     0.694101991692336,
@@ -132,7 +132,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(gyro * (f64::consts::PI/180.0), accel, mag);
+    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag);
 
     let expected = Quaternion::new( 0.7266895209095908,
                                     0.6862575490365720,
@@ -160,7 +160,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(gyro * (f64::consts::PI/180.0), accel);
+    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel);
 
 
     let expected = Quaternion::new( 0.7197849027430218,


### PR DESCRIPTION
Modifies the `Ahrs` function signature but boosts performance by removing extra copy operations.