### PR TITLE
Return Result with state reference for update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add ahrs-rs to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ahrs = "0.1.3"
+ahrs = "0.1.4"
 ```
 
 Here's a simple example that updates the filter state with arbitrary sensor data:
@@ -37,10 +37,12 @@ fn main() {
     let magnetometer = Vector3::new(0.5, 0.6, 0.7);
     
     // Run inputs through AHRS filter (gyroscope must be radians/s)
-    ahrs.update( &(gyroscope * (f64::consts::PI/180.0)), &accelerometer, &magnetometer);
+    let quat: &Quaternion<f64> = ahrs.update( &(gyroscope * (f64::consts::PI/180.0)),
+                                              &accelerometer,
+                                              &magnetometer ).unwrap();
     
     // Do something with the updated state quaternion
-    println!("{}", ahrs.quat);
+    println!("{}", quat);
 }
 
 ```

--- a/benches/ahrs.rs
+++ b/benches/ahrs.rs
@@ -41,14 +41,14 @@ macro_rules! _bench_ahrs2(
     // iterations is 1
     ($b: ident, $t: ident, $op: ident, 1, $( $x: expr ),* ) => {
         let mut ahrs = $t::default();
-        $b.iter(|| ahrs.$op( &$($x),* ));
+        $b.iter(|| test::black_box( ahrs.$op( &$($x),* ) ).unwrap());
     };
     // iterations is $n, and $x is expanded based on input from `_bench_ahrs1` operation
     ($b: ident, $t: ident, $op: ident, $n: expr, $( $x: expr ),* )  => {
         $b.iter(|| {
           let mut ahrs = $t::default();
           for n in 0..$n {
-              ahrs.$op( $( &$x[n] ),* );
+              test::black_box(ahrs.$op( $( &$x[n] ),* ).unwrap());
           }
         })
     };

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -4,12 +4,18 @@ use na::{Vector3, BaseFloat, Quaternion};
 /// Trait for implementing an AHRS filter.
 pub trait Ahrs<N: BaseFloat> {
 
-  /// Updates the current state quaternion using 9dof IMU values, made up by `gyroscope`,
+  /// Attempts to update the current state quaternion using 9dof IMU values, made up by `gyroscope`,
   /// `accelerometer`, and `magnetometer`.
+  ///
+  /// Returns a reference to the updated quaternion on success, or in the case of failure, an
+  /// `Err(&str)` containing the reason.
   fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str>;
 
-  /// Updates the current state quaternion using 6dof IMU values, made up by `gyroscope` &
+  /// Attempts to update the current state quaternion using 6dof IMU values, made up by `gyroscope` &
   /// `accelerometer`.
+  ///
+  /// Returns a reference to the updated quaternion on success, or in the case of failure, an
+  /// `Err(&str)` containing the reason.
   fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str>;
 }
 

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -1,15 +1,15 @@
 
-use na::{Vector3, BaseFloat};
+use na::{Vector3, BaseFloat, Quaternion};
 
 /// Trait for implementing an AHRS filter.
 pub trait Ahrs<N: BaseFloat> {
 
   /// Updates the current state quaternion using 9dof IMU values, made up by `gyroscope`,
   /// `accelerometer`, and `magnetometer`.
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str>;
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str>;
 
   /// Updates the current state quaternion using 6dof IMU values, made up by `gyroscope` &
   /// `accelerometer`.
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str>;
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str>;
 }
 

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -6,10 +6,10 @@ pub trait Ahrs<N: BaseFloat> {
 
   /// Updates the current state quaternion using 9dof IMU values, made up by `gyroscope`,
   /// `accelerometer`, and `magnetometer`.
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool;
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str>;
 
   /// Updates the current state quaternion using 6dof IMU values, made up by `gyroscope` &
   /// `accelerometer`.
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool;
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str>;
 }
 

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -97,7 +97,7 @@ impl<N: BaseFloat> Madgwick<N> {
 
 impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str> {
     let q = self.quat;
     
     let zero: N = na::zero();
@@ -108,13 +108,13 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Normalize accelerometer measurement
     let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
-        None => { return false; }
+        None => { return Err("Accelerometer norm divided by zero.") }
     };
     
     // Normalize magnetometer measurement
     let mag = match try_normalize(magnetometer, zero) {
         Some(n) => n,
-        None => { return false; }
+        None => { return Err("Magnetometer norm divided by zero."); }
     };
 
     // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
@@ -148,10 +148,10 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    true
+    Ok(())
   }
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str> {
     let q = self.quat;
 
     let zero: N = na::zero();
@@ -162,7 +162,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Normalize accelerometer measurement
     let accel = match try_normalize(accelerometer, zero) {
       Some(n) => n,
-      None => { return false; }
+      None => { return Err("Accelerator norm divided by zero."); }
     };
 
     // Gradient descent algorithm corrective step
@@ -185,7 +185,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    true
+    Ok(())
   }
 
 }

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -97,7 +97,7 @@ impl<N: BaseFloat> Madgwick<N> {
 
 impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str> {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
     let q = self.quat;
     
     let zero: N = na::zero();
@@ -148,10 +148,10 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    Ok(())
+    Ok(&self.quat)
   }
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str> {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
     let q = self.quat;
 
     let zero: N = na::zero();
@@ -185,7 +185,7 @@ impl<N: BaseFloat> Ahrs<N> for Madgwick<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    Ok(())
+    Ok(&self.quat)
   }
 
 }

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -110,7 +110,7 @@ impl<N: BaseFloat> Mahony<N> {
 }
 impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str> {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
 
     let q = self.quat;
     
@@ -163,10 +163,10 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    Ok(())
+    Ok(&self.quat)
   }
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str> {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
 
     let q = self.quat;
     
@@ -204,7 +204,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    Ok(())
+    Ok(&self.quat)
   }
 
 }

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -110,7 +110,7 @@ impl<N: BaseFloat> Mahony<N> {
 }
 impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> bool {
+  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<(), &str> {
 
     let q = self.quat;
     
@@ -121,13 +121,13 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Normalize accelerometer measurement
     let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
-        None => { return false; }
+        None => { return Err("Accelerometer norm divided by zero."); }
     };
     
     // Normalize magnetometer measurement
     let mag = match try_normalize(magnetometer, zero) {
         Some(n) => n,
-        None => { return false; }
+        None => { return Err("Magnetometer norm divided by zero."); }
     };
 
     // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
@@ -163,10 +163,10 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    true
+    Ok(())
   }
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> bool {
+  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<(), &str> {
 
     let q = self.quat;
     
@@ -177,7 +177,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Normalize accelerometer measurement
     let accel = match try_normalize(accelerometer, zero) {
         Some(n) => n,
-        None => { return false; }
+        None => { return Err("Accelerometer norm divided by zero."); }
     };
 
     let v = Vector3::new(
@@ -204,7 +204,7 @@ impl<N: BaseFloat> Ahrs<N> for Mahony<N> {
     // Integrate to yield quaternion
     self.quat = na::normalize( &(q + qDot * self.sample_period) );
 
-    true
+    Ok(())
   }
 
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -75,7 +75,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
+    let actual = ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
 
     let expected = Quaternion::new( 0.7235467139148768,
                                     0.6888611247479446,
@@ -84,9 +84,9 @@ extern crate ahrs;
 
     let fail_message = format!("quaternions did not match:\n\
           actual: {:?}\n\
-          expect: {:?}", ahrs.quat, expected);
+          expect: {:?}", actual, expected);
 
-    assert!(approx_eq(&ahrs.quat, &expected), fail_message);
+    assert!(approx_eq(actual, &expected), fail_message);
   }
 
   #[test]
@@ -103,7 +103,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
+    let actual = ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
 
     let expected = Quaternion::new( 0.7190919791549198,
                                     0.694101991692336,
@@ -112,9 +112,9 @@ extern crate ahrs;
 
     let fail_message = format!("quaternions did not match:\n\
         actual: {:?}\n\
-        expect: {:?}", ahrs.quat, expected);
+        expect: {:?}", actual, expected);
 
-    assert!(approx_eq(&ahrs.quat, &expected), fail_message);
+    assert!(approx_eq(actual, &expected), fail_message);
   }
 
   #[test]
@@ -132,7 +132,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
+    let actual = ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
 
     let expected = Quaternion::new( 0.7266895209095908,
                                     0.6862575490365720,
@@ -141,9 +141,9 @@ extern crate ahrs;
 
     let fail_message = format!("quaternions did not match:\n\
           actual: {:?}\n\
-          expect: {:?}", ahrs.quat, expected);
+          expect: {:?}", actual, expected);
 
-    assert!(approx_eq(&ahrs.quat, &expected), fail_message);
+    assert!(approx_eq(actual, &expected), fail_message);
   }
 
   #[test]
@@ -160,7 +160,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
+    let actual = ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
 
 
     let expected = Quaternion::new( 0.7197849027430218,
@@ -170,9 +170,9 @@ extern crate ahrs;
 
     let fail_message = format!("quaternions did not match:\n\
         actual: {:?}\n\
-        expect: {:?}", ahrs.quat, expected);
+        expect: {:?}", actual, expected);
 
-    assert!(approx_eq(&ahrs.quat, &expected), fail_message);
+    assert!(approx_eq(actual, &expected), fail_message);
   }
 
 //}

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -24,7 +24,7 @@ extern crate ahrs;
 
     let fail_message = "Normalizing zero-value accel should have failed.";
 
-    assert!(res == false, fail_message);
+    assert!(res.is_err(), fail_message);
   }
 
   #[test]
@@ -41,7 +41,7 @@ extern crate ahrs;
 
     let fail_message = "Normalizing zero-value mag should have failed.";
 
-    assert!(res == false, fail_message);
+    assert!(res.is_err(), fail_message);
   }
 
   #[test]
@@ -57,7 +57,7 @@ extern crate ahrs;
 
     let fail_message = "Normalizing zero-value accel should have failed.";
 
-    assert!(res == false, fail_message);
+    assert!(res.is_err(), fail_message);
   }
 
   #[test]
@@ -75,7 +75,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag);
+    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
 
     let expected = Quaternion::new( 0.7235467139148768,
                                     0.6888611247479446,
@@ -103,7 +103,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel);
+    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
 
     let expected = Quaternion::new( 0.7190919791549198,
                                     0.694101991692336,
@@ -132,7 +132,7 @@ extern crate ahrs;
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
     let mag = Vector3::new(0.171875, -0.4536133, -0.04101563);
 
-    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag);
+    ahrs.update(&(gyro * (f64::consts::PI/180.0)), &accel, &mag).unwrap();
 
     let expected = Quaternion::new( 0.7266895209095908,
                                     0.6862575490365720,
@@ -160,7 +160,7 @@ extern crate ahrs;
     let accel = Vector3::new(0.06640625, 0.9794922, -0.01269531);
     let gyro = Vector3::new(68.75, 34.25, 3.0625);
 
-    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel);
+    ahrs.update_imu(&(gyro * (f64::consts::PI/180.0)), &accel).unwrap();
 
 
     let expected = Quaternion::new( 0.7197849027430218,


### PR DESCRIPTION
Replaces the returned boolean which had implicitly indicated success. A reference to the quaternion state (wrapped in Result) is now returned on success, but is still also accessible as a public field. This may change in the future depending on ergonomics.