### PR TITLE
Feature flag `field_access`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rust:
   - nightly
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose
+  - cargo build --all-features --verbose
+  - cargo test --all-features --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "ahrs"
 version = "0.2.0"
-authors = ["jmagnuson"]
+authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 
 description = "A Rust port of Madgwick's AHRS algorithm"
 repository = "https://github.com/jmagnuson/ahrs-rs"
@@ -16,14 +16,9 @@ name = "ahrs"
 path = "src/lib.rs"
 
 [dependencies]
-nalgebra = "0.14.0"
-alga  = "0.5.2"
+nalgebra = "0.17"
+alga  = "0.8"
 
 [dev-dependencies]
-rand = "0.3.15"
-approx = "0.1.1"
-
-# Dev profile, used for `cargo build`
-[profile.dev]
-opt-level = 0  # Controls the --opt-level the compiler builds with
-debug = true   # Controls whether the compiler passes -g or `--cfg ndebug`
+rand = "0.6"
+approx = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 keywords = ["ahrs", "madgwick", "imu", "kalman", "accelerometer"]
 license = "GPL-3.0"
 
+[features]
+default = []
+field_access = []
+
 [lib]
 name = "ahrs"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ fn main() {
 
 Crate [nalgebra](https://crates.io/crates/nalgebra) is also needed as a dependency for its algebraic types `Vector3` and `Quaternion`.
 
+## Feature flags
+
+### `field_access`
+
+Gives [im]mutable access to inner algorithm struct fields that aren't normally exposed. The exposed
+API is considered unstable for the time-being, but is nevertheless a useful feature. For example:
+
+```rust
+use ahrs::Madgwick;
+
+let mut ahrs = Madgwick::default();
+
+#[cfg(feature = "field_access")]
+{
+    let sample_period: &mut f64 = ahrs.sample_period_mut();
+    *sample_period = 0.5;
+}
+```
+
+
 ## License
 
 GPLv3

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -123,21 +123,24 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
     let b = Quaternion::new( zero, Vector2::new(h[0], h[1]).norm(), zero, h[2] );
 
     // Gradient descent algorithm corrective step
+    #[rustfmt::skip]
     let F = Vector6::new(
-      two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
-      two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
-      two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
-      two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]) - mag[0],
-      two*b[0]*(q[0]*q[1] - q[3]*q[2]) + two*b[2]*(       q[3]*q[0] + q[1]*q[2]) - mag[1],
-      two*b[0]*(q[3]*q[1] + q[0]*q[2]) + two*b[2]*(half - q[0]*q[0] - q[1]*q[1]) - mag[2] );
+        two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
+        two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
+        two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
+        two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]) - mag[0],
+        two*b[0]*(q[0]*q[1] - q[3]*q[2])        + two*b[2]*(       q[3]*q[0] + q[1]*q[2]) - mag[1],
+        two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1]) - mag[2]
+    );
 
+    #[rustfmt::skip]
     let J_t = Matrix6::new(
-      -two*q[1], two*q[0],       zero,                -two*b[2]*q[1], -two*b[0]*q[2]+two*b[2]*q[0], two*b[0]*q[1],
-       two*q[2], two*q[3], -four*q[0],                 two*b[2]*q[2],  two*b[0]*q[1]+two*b[2]*q[3], two*b[0]*q[2]-four*b[2]*q[0],
-      -two*q[3], two*q[2], -four*q[1], -four*b[0]*q[1]-two*b[2]*q[3],  two*b[0]*q[0]+two*b[2]*q[2], two*b[0]*q[3]-four*b[2]*q[1],
-       two*q[0], two*q[1],       zero, -four*b[0]*q[2]+two*b[2]*q[0], -two*b[0]*q[3]+two*b[2]*q[1], two*b[0]*q[0],
-       zero, zero, zero, zero, zero, zero,
-       zero, zero, zero, zero, zero, zero
+        -two*q[1], two*q[0],       zero,                -two*b[2]*q[1], -two*b[0]*q[2]+two*b[2]*q[0], two*b[0]*q[1],
+         two*q[2], two*q[3], -four*q[0],                 two*b[2]*q[2],  two*b[0]*q[1]+two*b[2]*q[3], two*b[0]*q[2]-four*b[2]*q[0],
+        -two*q[3], two*q[2], -four*q[1], -four*b[0]*q[1]-two*b[2]*q[3],  two*b[0]*q[0]+two*b[2]*q[2], two*b[0]*q[3]-four*b[2]*q[1],
+         two*q[0], two*q[1],       zero, -four*b[0]*q[2]+two*b[2]*q[0], -two*b[0]*q[3]+two*b[2]*q[1], two*b[0]*q[0],
+         zero, zero, zero, zero, zero, zero,
+         zero, zero, zero, zero, zero, zero
     );
 
     let step = (J_t * F).normalize();
@@ -167,15 +170,21 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
     };
 
     // Gradient descent algorithm corrective step
-    let F = Vector4::new( two*(      q[0]*q[2] - q[3]*q[1]) - accel[0],
-                          two*(      q[3]*q[0] + q[1]*q[2]) - accel[1],
-                          two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
-                          zero );
+    #[rustfmt::skip]
+    let F = Vector4::new(
+        two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
+        two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
+        two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
+        zero
+    );
 
-    let J_t = Matrix4::new( -two*q[1], two*q[0],       zero, zero,
-                             two*q[2], two*q[3], -four*q[0], zero,
-                            -two*q[3], two*q[2], -four*q[1], zero,
-                             two*q[0], two*q[1],       zero, zero );
+    #[rustfmt::skip]
+    let J_t = Matrix4::new(
+        -two*q[1], two*q[0],       zero, zero,
+         two*q[2], two*q[3], -four*q[0], zero,
+        -two*q[3], two*q[2], -four*q[1], zero,
+         two*q[0], two*q[1],       zero, zero
+    );
 
     let step = (J_t * F).normalize();
 

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -96,6 +96,39 @@ impl<N: Real> Madgwick<N> {
     }
 }
 
+#[cfg(feature = "field_access")]
+impl<N: Real> Madgwick<N> {
+    /// Expected sampling period, in seconds.
+    pub fn sample_period(&self) -> N {
+        self.sample_period
+    }
+
+    /// Mutable reference to expected sampling period, in seconds.
+    pub fn sample_period_mut(&mut self) -> &mut N {
+        &mut self.sample_period
+    }
+
+    /// Filter gain.
+    pub fn beta(&self) -> N {
+        self.beta
+    }
+
+    /// Mutable reference to filter gain.
+    pub fn beta_mut(&mut self) -> &mut N {
+        &mut self.beta
+    }
+
+    /// Filter state quaternion.
+    pub fn quat(&self) -> Quaternion<N> {
+        self.quat
+    }
+
+    /// Mutable reference to filter state quaternion.
+    pub fn quat_mut(&mut self) -> &mut Quaternion<N> {
+        &mut self.quat
+    }
+}
+
 impl<N: Real> Ahrs<N> for Madgwick<N> {
     fn update(
         &mut self,

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -140,14 +140,14 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
     );
 
         #[rustfmt::skip]
-    let J_t = Matrix6::new(
-        -two*q[1], two*q[0],       zero,                -two*b[2]*q[1], -two*b[0]*q[2]+two*b[2]*q[0], two*b[0]*q[1],
-         two*q[2], two*q[3], -four*q[0],                 two*b[2]*q[2],  two*b[0]*q[1]+two*b[2]*q[3], two*b[0]*q[2]-four*b[2]*q[0],
-        -two*q[3], two*q[2], -four*q[1], -four*b[0]*q[1]-two*b[2]*q[3],  two*b[0]*q[0]+two*b[2]*q[2], two*b[0]*q[3]-four*b[2]*q[1],
-         two*q[0], two*q[1],       zero, -four*b[0]*q[2]+two*b[2]*q[0], -two*b[0]*q[3]+two*b[2]*q[1], two*b[0]*q[0],
-         zero, zero, zero, zero, zero, zero,
-         zero, zero, zero, zero, zero, zero
-    );
+        let J_t = Matrix6::new(
+            -two*q[1], two*q[0],       zero,                -two*b[2]*q[1], -two*b[0]*q[2]+two*b[2]*q[0], two*b[0]*q[1],
+             two*q[2], two*q[3], -four*q[0],                 two*b[2]*q[2],  two*b[0]*q[1]+two*b[2]*q[3], two*b[0]*q[2]-four*b[2]*q[0],
+            -two*q[3], two*q[2], -four*q[1], -four*b[0]*q[1]-two*b[2]*q[3],  two*b[0]*q[0]+two*b[2]*q[2], two*b[0]*q[3]-four*b[2]*q[1],
+             two*q[0], two*q[1],       zero, -four*b[0]*q[2]+two*b[2]*q[0], -two*b[0]*q[3]+two*b[2]*q[1], two*b[0]*q[0],
+             zero, zero, zero, zero, zero, zero,
+             zero, zero, zero, zero, zero, zero
+        );
 
         let step = (J_t * F).normalize();
 
@@ -183,20 +183,20 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
 
         // Gradient descent algorithm corrective step
         #[rustfmt::skip]
-    let F = Vector4::new(
-        two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
-        two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
-        two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
-        zero
-    );
+        let F = Vector4::new(
+            two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
+            two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
+            two*(half - q[0]*q[0] - q[1]*q[1]) - accel[2],
+            zero
+        );
 
         #[rustfmt::skip]
-    let J_t = Matrix4::new(
-        -two*q[1], two*q[0],       zero, zero,
-         two*q[2], two*q[3], -four*q[0], zero,
-        -two*q[3], two*q[2], -four*q[1], zero,
-         two*q[0], two*q[1],       zero, zero
-    );
+        let J_t = Matrix4::new(
+            -two*q[1], two*q[0],       zero, zero,
+             two*q[2], two*q[3], -four*q[0], zero,
+            -two*q[3], two*q[2], -four*q[1], zero,
+             two*q[0], two*q[1],       zero, zero
+        );
 
         let step = (J_t * F).normalize();
 

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -55,7 +55,6 @@ impl<N: Real> Madgwick<N> {
   /// use ahrs::Madgwick;
   ///
   /// fn main() {
-  ///
   ///     let ahrs = Madgwick::new(0.002390625f64, 0.1);
   /// }
   /// ```
@@ -81,10 +80,11 @@ impl<N: Real> Madgwick<N> {
   /// use ahrs::Madgwick;
   ///
   /// fn main() {
-  ///
-  ///     let ahrs = Madgwick::new_with_quat( 0.002390625f64,
-  ///                                         0.1,
-  ///                                         Quaternion::new(1.0, 0.0, 0.0, 0.0));
+  ///     let ahrs = Madgwick::new_with_quat(
+  ///         0.002390625f64,
+  ///         0.1,
+  ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+  ///     );
   /// }
   /// ```
   pub fn new_with_quat(sample_period: N, beta: N, quat: Quaternion<N>) -> Self {

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -1,129 +1,135 @@
 #![allow(non_snake_case)]
 
-use na::{Vector2, Vector3, Vector4, Vector6, Matrix6, Matrix4, Quaternion};
-use na;
 use ahrs::Ahrs;
 use alga::general::Real;
+use na;
+use na::{Matrix4, Matrix6, Quaternion, Vector2, Vector3, Vector4, Vector6};
 
 /// Madgwick AHRS implementation.
 #[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub struct Madgwick<N: Real> {
-
-  /// Expected sampling period, in seconds.
-  sample_period: N,
-  /// Filter gain.
-  beta: N,
-  /// Filter state quaternion.
-  pub quat: Quaternion<N>
-
+    /// Expected sampling period, in seconds.
+    sample_period: N,
+    /// Filter gain.
+    beta: N,
+    /// Filter state quaternion.
+    pub quat: Quaternion<N>,
 }
 
 impl Default for Madgwick<f64> {
-
-  /// Creates a new `Madgwick` instance with default filter parameters:
-  ///
-  /// ```rust,ignore
-  /// Madgwick {
-  ///     sample_period: 1.0f64/256.0,
-  ///     beta: 0.1f64,
-  ///     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
-  /// }
-  /// ```
-  fn default() -> Madgwick<f64> {
-    Madgwick { sample_period: (1.0f64)/(256.0),
-               beta: 0.1f64,
-               quat: Quaternion::new(1.0f64, 0.0, 0.0, 0.0)
+    /// Creates a new `Madgwick` instance with default filter parameters:
+    ///
+    /// ```rust,ignore
+    /// Madgwick {
+    ///     sample_period: 1.0f64/256.0,
+    ///     beta: 0.1f64,
+    ///     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
+    /// }
+    /// ```
+    fn default() -> Madgwick<f64> {
+        Madgwick {
+            sample_period: (1.0f64) / (256.0),
+            beta: 0.1f64,
+            quat: Quaternion::new(1.0f64, 0.0, 0.0, 0.0),
+        }
     }
-  }
-
 }
 
 impl<N: Real> Madgwick<N> {
-
-  /// Creates a new `Madgwick` AHRS instance with identity quaternion.
-  ///
-  /// # Arguments
-  ///
-  /// * `sample_period` - The expected sensor sampling period in seconds.
-  /// * `beta` - Filter gain.
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// extern crate ahrs;
-  ///
-  /// use ahrs::Madgwick;
-  ///
-  /// fn main() {
-  ///     let ahrs = Madgwick::new(0.002390625f64, 0.1);
-  /// }
-  /// ```
-  pub fn new(sample_period: N, beta: N) -> Self {
-    Madgwick::new_with_quat(sample_period, beta, Quaternion::new(N::one(), N::zero(), N::zero(), N::zero()))
-  }
-
-  /// Creates a new `Madgwick` AHRS instance with given quaternion.
-  ///
-  /// # Arguments
-  ///
-  /// * `sample_period` - The expected sensor sampling period in seconds.
-  /// * `beta` - Filter gain.
-  /// * `quat` - Existing filter state quaternion.
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// extern crate nalgebra as na;
-  /// extern crate ahrs;
-  ///
-  /// use na::Quaternion;
-  /// use ahrs::Madgwick;
-  ///
-  /// fn main() {
-  ///     let ahrs = Madgwick::new_with_quat(
-  ///         0.002390625f64,
-  ///         0.1,
-  ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
-  ///     );
-  /// }
-  /// ```
-  pub fn new_with_quat(sample_period: N, beta: N, quat: Quaternion<N>) -> Self {
-    Madgwick { sample_period: sample_period,
-      beta: beta,
-      quat: quat
+    /// Creates a new `Madgwick` AHRS instance with identity quaternion.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample_period` - The expected sensor sampling period in seconds.
+    /// * `beta` - Filter gain.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate ahrs;
+    ///
+    /// use ahrs::Madgwick;
+    ///
+    /// fn main() {
+    ///     let ahrs = Madgwick::new(0.002390625f64, 0.1);
+    /// }
+    /// ```
+    pub fn new(sample_period: N, beta: N) -> Self {
+        Madgwick::new_with_quat(
+            sample_period,
+            beta,
+            Quaternion::new(N::one(), N::zero(), N::zero(), N::zero()),
+        )
     }
-  }
 
+    /// Creates a new `Madgwick` AHRS instance with given quaternion.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample_period` - The expected sensor sampling period in seconds.
+    /// * `beta` - Filter gain.
+    /// * `quat` - Existing filter state quaternion.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate nalgebra as na;
+    /// extern crate ahrs;
+    ///
+    /// use na::Quaternion;
+    /// use ahrs::Madgwick;
+    ///
+    /// fn main() {
+    ///     let ahrs = Madgwick::new_with_quat(
+    ///         0.002390625f64,
+    ///         0.1,
+    ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    ///     );
+    /// }
+    /// ```
+    pub fn new_with_quat(sample_period: N, beta: N, quat: Quaternion<N>) -> Self {
+        Madgwick {
+            sample_period: sample_period,
+            beta: beta,
+            quat: quat,
+        }
+    }
 }
 
 impl<N: Real> Ahrs<N> for Madgwick<N> {
+    fn update(
+        &mut self,
+        gyroscope: &Vector3<N>,
+        accelerometer: &Vector3<N>,
+        magnetometer: &Vector3<N>,
+    ) -> Result<&Quaternion<N>, &str> {
+        let q = self.quat;
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
-    let q = self.quat;
-    
-    let zero: N = na::zero();
-    let two: N = na::convert(2.0);
-    let four: N = na::convert(4.0);
-    let half: N = na::convert(0.5);
+        let zero: N = na::zero();
+        let two: N = na::convert(2.0);
+        let four: N = na::convert(4.0);
+        let half: N = na::convert(0.5);
 
-    // Normalize accelerometer measurement
-    let accel = match accelerometer.try_normalize(zero) {
-        Some(n) => n,
-        None => { return Err("Accelerometer norm divided by zero.") }
-    };
-    
-    // Normalize magnetometer measurement
-    let mag = match magnetometer.try_normalize(zero) {
-        Some(n) => n,
-        None => { return Err("Magnetometer norm divided by zero."); }
-    };
+        // Normalize accelerometer measurement
+        let accel = match accelerometer.try_normalize(zero) {
+            Some(n) => n,
+            None => return Err("Accelerometer norm divided by zero."),
+        };
 
-    // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
-    let h = q * ( Quaternion::from_parts(zero, mag) * q.conjugate() );
-    let b = Quaternion::new( zero, Vector2::new(h[0], h[1]).norm(), zero, h[2] );
+        // Normalize magnetometer measurement
+        let mag = match magnetometer.try_normalize(zero) {
+            Some(n) => n,
+            None => {
+                return Err("Magnetometer norm divided by zero.");
+            }
+        };
 
-    // Gradient descent algorithm corrective step
-    #[rustfmt::skip]
+        // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
+        let h = q * (Quaternion::from_parts(zero, mag) * q.conjugate());
+        let b = Quaternion::new(zero, Vector2::new(h[0], h[1]).norm(), zero, h[2]);
+
+        // Gradient descent algorithm corrective step
+        #[rustfmt::skip]
     let F = Vector6::new(
         two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
         two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
@@ -133,7 +139,7 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
         two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1]) - mag[2]
     );
 
-    #[rustfmt::skip]
+        #[rustfmt::skip]
     let J_t = Matrix6::new(
         -two*q[1], two*q[0],       zero,                -two*b[2]*q[1], -two*b[0]*q[2]+two*b[2]*q[0], two*b[0]*q[1],
          two*q[2], two*q[3], -four*q[0],                 two*b[2]*q[2],  two*b[0]*q[1]+two*b[2]*q[3], two*b[0]*q[2]-four*b[2]*q[0],
@@ -143,34 +149,40 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
          zero, zero, zero, zero, zero, zero
     );
 
-    let step = (J_t * F).normalize();
+        let step = (J_t * F).normalize();
 
-    // Compute rate of change for quaternion
-    let qDot = q * Quaternion::from_parts(zero, *gyroscope)
-        * half - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
+        // Compute rate of change for quaternion
+        let qDot = q * Quaternion::from_parts(zero, *gyroscope) * half
+            - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
 
-    // Integrate to yield quaternion
-    self.quat = (q + qDot * self.sample_period).normalize();
+        // Integrate to yield quaternion
+        self.quat = (q + qDot * self.sample_period).normalize();
 
-    Ok(&self.quat)
-  }
+        Ok(&self.quat)
+    }
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
-    let q = self.quat;
+    fn update_imu(
+        &mut self,
+        gyroscope: &Vector3<N>,
+        accelerometer: &Vector3<N>,
+    ) -> Result<&Quaternion<N>, &str> {
+        let q = self.quat;
 
-    let zero: N = na::zero();
-    let two: N = na::convert(2.0);
-    let four: N = na::convert(4.0);
-    let half: N = na::convert(0.5);
+        let zero: N = na::zero();
+        let two: N = na::convert(2.0);
+        let four: N = na::convert(4.0);
+        let half: N = na::convert(0.5);
 
-    // Normalize accelerometer measurement
-    let accel = match accelerometer.try_normalize(zero) {
-      Some(n) => n,
-      None => { return Err("Accelerator norm divided by zero."); }
-    };
+        // Normalize accelerometer measurement
+        let accel = match accelerometer.try_normalize(zero) {
+            Some(n) => n,
+            None => {
+                return Err("Accelerator norm divided by zero.");
+            }
+        };
 
-    // Gradient descent algorithm corrective step
-    #[rustfmt::skip]
+        // Gradient descent algorithm corrective step
+        #[rustfmt::skip]
     let F = Vector4::new(
         two*(       q[0]*q[2] - q[3]*q[1]) - accel[0],
         two*(       q[3]*q[0] + q[1]*q[2]) - accel[1],
@@ -178,7 +190,7 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
         zero
     );
 
-    #[rustfmt::skip]
+        #[rustfmt::skip]
     let J_t = Matrix4::new(
         -two*q[1], two*q[0],       zero, zero,
          two*q[2], two*q[3], -four*q[0], zero,
@@ -186,17 +198,15 @@ impl<N: Real> Ahrs<N> for Madgwick<N> {
          two*q[0], two*q[1],       zero, zero
     );
 
-    let step = (J_t * F).normalize();
+        let step = (J_t * F).normalize();
 
-    // Compute rate of change of quaternion
-    let qDot = (q * Quaternion::from_parts(zero, *gyroscope))
-        * half - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
+        // Compute rate of change of quaternion
+        let qDot = (q * Quaternion::from_parts(zero, *gyroscope)) * half
+            - Quaternion::new(step[0], step[1], step[2], step[3]) * self.beta;
 
-    // Integrate to yield quaternion
-    self.quat = (q + qDot * self.sample_period).normalize();
+        // Integrate to yield quaternion
+        self.quat = (q + qDot * self.sample_period).normalize();
 
-    Ok(&self.quat)
-  }
-
+        Ok(&self.quat)
+    }
 }
-

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use na::{Vector2, Vector3, Quaternion, try_normalize, norm};
+use na::{Vector2, Vector3, Quaternion};
 use na;
 use ahrs::Ahrs;
 use alga::general::Real;
@@ -120,20 +120,20 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
     let half: N = na::convert(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(accelerometer, zero) {
+    let accel = match accelerometer.try_normalize(zero) {
         Some(n) => n,
         None => { return Err("Accelerometer norm divided by zero."); }
     };
     
     // Normalize magnetometer measurement
-    let mag = match try_normalize(magnetometer, zero) {
+    let mag = match magnetometer.try_normalize(zero) {
         Some(n) => n,
         None => { return Err("Magnetometer norm divided by zero."); }
     };
 
     // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
     let h = q * ( Quaternion::from_parts(zero, mag) * q.conjugate() );
-    let b = Quaternion::new( zero, norm(&Vector2::new(h[0], h[1])), zero, h[2] );
+    let b = Quaternion::new( zero, Vector2::new(h[0], h[1]).norm(), zero, h[2] );
  
     let v = Vector3::new(
       two*( q[0]*q[2] - q[3]*q[1] ),
@@ -162,7 +162,7 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
     let qDot = q * Quaternion::from_parts(zero, gyro) * half;
 
     // Integrate to yield quaternion
-    self.quat = na::normalize( &(q + qDot * self.sample_period) );
+    self.quat = (q + qDot * self.sample_period).normalize();
 
     Ok(&self.quat)
   }
@@ -176,7 +176,7 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
     let half: N = na::convert(0.5);
 
     // Normalize accelerometer measurement
-    let accel = match try_normalize(accelerometer, zero) {
+    let accel = match accelerometer.try_normalize(zero) {
         Some(n) => n,
         None => { return Err("Accelerometer norm divided by zero."); }
     };
@@ -202,7 +202,7 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
     let qDot = q * Quaternion::from_parts(zero, gyro) * half;
 
     // Integrate to yield quaternion
-    self.quat = na::normalize( &(q + qDot * self.sample_period) );
+    self.quat = (q + qDot * self.sample_period).normalize();
 
     Ok(&self.quat)
   }

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -43,7 +43,6 @@ impl Default for Mahony<f64> {
     }
 }
 
-
 impl<N: Real> Mahony<N> {
     /// Creates a new Mahony AHRS instance with identity quaternion.
     ///
@@ -110,6 +109,60 @@ impl<N: Real> Mahony<N> {
         }
     }
 }
+
+#[cfg(feature = "field_access")]
+impl<N: Real> Mahony<N> {
+    /// Expected sampling period, in seconds.
+    pub fn sample_period(&self) -> N {
+        self.sample_period
+    }
+
+    /// Mutable reference to expected sampling period, in seconds.
+    pub fn sample_period_mut(&mut self) -> &mut N {
+        &mut self.sample_period
+    }
+
+    /// Proportional filter gain constant.
+    pub fn kp(&self) -> N {
+        self.kp
+    }
+
+    /// Mutable reference to proportional filter gain constant.
+    pub fn kp_mut(&mut self) -> &mut N {
+        &mut self.kp
+    }
+
+    /// Integral filter gain constant.
+    pub fn ki(&self) -> N {
+        self.ki
+    }
+
+    /// Mutable reference to integral filter gain constant.
+    pub fn ki_mut(&mut self) -> &mut N {
+        &mut self.ki
+    }
+
+    /// Integral error vector.
+    pub fn e_int(&self) -> Vector3<N> {
+        self.e_int
+    }
+
+    /// Mutable reference to integral error vector.
+    pub fn e_int_mut(&mut self) -> &mut Vector3<N> {
+        &mut self.e_int
+    }
+
+    /// Filter state quaternion.
+    pub fn quat(&self) -> Quaternion<N> {
+        self.quat
+    }
+
+    /// Mutable reference to filter state quaternion.
+    pub fn quat_mut(&mut self) -> &mut Quaternion<N> {
+        &mut self.quat
+    }
+}
+
 impl<N: Real> Ahrs<N> for Mahony<N> {
     fn update(
         &mut self,

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -65,7 +65,6 @@ impl<N: Real> Mahony<N> {
   /// use ahrs::Mahony;
   ///
   /// fn main() {
-  ///
   ///     let ahrs = Mahony::new(0.002390625f64, 0.5, 0.0);
   /// }
   /// ```
@@ -92,11 +91,12 @@ impl<N: Real> Mahony<N> {
   /// use ahrs::Mahony;
   ///
   /// fn main() {
-  ///
-  ///     let ahrs = Mahony::new_with_quat( 0.002390625f64,
-  ///                                       0.5,
-  ///                                       0.0,
-  ///                                       Quaternion::new(1.0, 0.0, 0.0, 0.0));
+  ///     let ahrs = Mahony::new_with_quat(
+  ///         0.002390625f64,
+  ///         0.5,
+  ///         0.0,
+  ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+  ///     );
   /// }
   /// ```
   pub fn new_with_quat(sample_period: N, kp: N, ki: N, quat: Quaternion<N>) -> Self {

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -1,15 +1,13 @@
 #![allow(non_snake_case)]
 
-use na::{Vector2, Vector3, Quaternion};
-use na;
 use ahrs::Ahrs;
 use alga::general::Real;
-
+use na;
+use na::{Quaternion, Vector2, Vector3};
 
 /// Mahony AHRS implementation.
 #[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub struct Mahony<N: Real> {
-
     /// Expected sampling period, in seconds.
     sample_period: N,
     /// Proportional filter gain constant.
@@ -19,12 +17,10 @@ pub struct Mahony<N: Real> {
     /// Integral error vector.
     e_int: Vector3<N>,
     /// Filter state quaternion.
-    pub quat: Quaternion<N>
-
+    pub quat: Quaternion<N>,
 }
 
 impl Default for Mahony<f64> {
-
     /// Creates a default `Mahony` AHRS instance with default filter parameters:
     ///
     /// ```rust,ignore
@@ -37,181 +33,200 @@ impl Default for Mahony<f64> {
     /// }
     /// ```
     fn default() -> Mahony<f64> {
-        Mahony { sample_period: (1.0f64)/(256.0),
-                 kp: 0.5f64,
-                 ki: 0.0f64,
-                 e_int: Vector3::new(0.0, 0.0, 0.0),
-                 quat: Quaternion::new(1.0f64, 0.0, 0.0, 0.0),
+        Mahony {
+            sample_period: (1.0f64) / (256.0),
+            kp: 0.5f64,
+            ki: 0.0f64,
+            e_int: Vector3::new(0.0, 0.0, 0.0),
+            quat: Quaternion::new(1.0f64, 0.0, 0.0, 0.0),
         }
     }
 }
 
 
 impl<N: Real> Mahony<N> {
-
-  /// Creates a new Mahony AHRS instance with identity quaternion.
-  ///
-  /// # Arguments
-  ///
-  /// * `sample_period` - The expected sensor sampling period in seconds.
-  /// * `kp` - Proportional filter gain constant.
-  /// * `ki` - Integral filter gain constant.
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// extern crate ahrs;
-  ///
-  /// use ahrs::Mahony;
-  ///
-  /// fn main() {
-  ///     let ahrs = Mahony::new(0.002390625f64, 0.5, 0.0);
-  /// }
-  /// ```
-  pub fn new(sample_period: N, kp: N, ki: N) -> Self {
-    Mahony::new_with_quat(sample_period, kp, ki, Quaternion::from_parts(N::one(), na::zero::<na::Vector3<N>>()))
-  }
-
-  /// Creates a new Mahony AHRS instance with given quaternion.
-  ///
-  /// # Arguments
-  ///
-  /// * `sample_period` - The expected sensor sampling period in seconds.
-  /// * `kp` - Proportional filter gain constant.
-  /// * `ki` - Integral filter gain constant.
-  /// * `quat` - Existing filter state quaternion.
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// extern crate nalgebra as na;
-  /// extern crate ahrs;
-  ///
-  /// use na::Quaternion;
-  /// use ahrs::Mahony;
-  ///
-  /// fn main() {
-  ///     let ahrs = Mahony::new_with_quat(
-  ///         0.002390625f64,
-  ///         0.5,
-  ///         0.0,
-  ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
-  ///     );
-  /// }
-  /// ```
-  pub fn new_with_quat(sample_period: N, kp: N, ki: N, quat: Quaternion<N>) -> Self {
-    Mahony { sample_period: sample_period,
-             kp: kp,
-             ki: ki,
-             e_int: na::zero(),
-             quat: quat
+    /// Creates a new Mahony AHRS instance with identity quaternion.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample_period` - The expected sensor sampling period in seconds.
+    /// * `kp` - Proportional filter gain constant.
+    /// * `ki` - Integral filter gain constant.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate ahrs;
+    ///
+    /// use ahrs::Mahony;
+    ///
+    /// fn main() {
+    ///     let ahrs = Mahony::new(0.002390625f64, 0.5, 0.0);
+    /// }
+    /// ```
+    pub fn new(sample_period: N, kp: N, ki: N) -> Self {
+        Mahony::new_with_quat(
+            sample_period,
+            kp,
+            ki,
+            Quaternion::from_parts(N::one(), na::zero::<na::Vector3<N>>()),
+        )
     }
-  }
 
+    /// Creates a new Mahony AHRS instance with given quaternion.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample_period` - The expected sensor sampling period in seconds.
+    /// * `kp` - Proportional filter gain constant.
+    /// * `ki` - Integral filter gain constant.
+    /// * `quat` - Existing filter state quaternion.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate nalgebra as na;
+    /// extern crate ahrs;
+    ///
+    /// use na::Quaternion;
+    /// use ahrs::Mahony;
+    ///
+    /// fn main() {
+    ///     let ahrs = Mahony::new_with_quat(
+    ///         0.002390625f64,
+    ///         0.5,
+    ///         0.0,
+    ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    ///     );
+    /// }
+    /// ```
+    pub fn new_with_quat(sample_period: N, kp: N, ki: N, quat: Quaternion<N>) -> Self {
+        Mahony {
+            sample_period: sample_period,
+            kp: kp,
+            ki: ki,
+            e_int: na::zero(),
+            quat: quat,
+        }
+    }
 }
 impl<N: Real> Ahrs<N> for Mahony<N> {
+    fn update(
+        &mut self,
+        gyroscope: &Vector3<N>,
+        accelerometer: &Vector3<N>,
+        magnetometer: &Vector3<N>,
+    ) -> Result<&Quaternion<N>, &str> {
+        let q = self.quat;
 
-  fn update( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N>, magnetometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
+        let zero: N = na::zero();
+        let two: N = na::convert(2.0);
+        let half: N = na::convert(0.5);
 
-    let q = self.quat;
-    
-    let zero: N = na::zero();
-    let two: N = na::convert(2.0);
-    let half: N = na::convert(0.5);
+        // Normalize accelerometer measurement
+        let accel = match accelerometer.try_normalize(zero) {
+            Some(n) => n,
+            None => {
+                return Err("Accelerometer norm divided by zero.");
+            }
+        };
 
-    // Normalize accelerometer measurement
-    let accel = match accelerometer.try_normalize(zero) {
-        Some(n) => n,
-        None => { return Err("Accelerometer norm divided by zero."); }
-    };
-    
-    // Normalize magnetometer measurement
-    let mag = match magnetometer.try_normalize(zero) {
-        Some(n) => n,
-        None => { return Err("Magnetometer norm divided by zero."); }
-    };
+        // Normalize magnetometer measurement
+        let mag = match magnetometer.try_normalize(zero) {
+            Some(n) => n,
+            None => {
+                return Err("Magnetometer norm divided by zero.");
+            }
+        };
 
-    // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
-    let h = q * ( Quaternion::from_parts(zero, mag) * q.conjugate() );
-    let b = Quaternion::new( zero, Vector2::new(h[0], h[1]).norm(), zero, h[2] );
+        // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
+        let h = q * (Quaternion::from_parts(zero, mag) * q.conjugate());
+        let b = Quaternion::new(zero, Vector2::new(h[0], h[1]).norm(), zero, h[2]);
 
-    #[rustfmt::skip]
+        #[rustfmt::skip]
     let v = Vector3::new(
         two*( q[0]*q[2] - q[3]*q[1] ),
         two*( q[3]*q[0] + q[1]*q[2] ),
         q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
     );
 
-    #[rustfmt::skip]
+        #[rustfmt::skip]
     let w = Vector3::new(
         two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]),
         two*b[0]*(q[0]*q[1] - q[3]*q[2])        + two*b[2]*(q[3]*q[0] + q[1]*q[2]),
         two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1])
     );
 
-    let e: Vector3<N> = accel.cross(&v) + mag.cross(&w);
-    
-    // Error is sum of cross product between estimated direction and measured direction of fields
-    if self.ki > zero  {
-        self.e_int += e * self.sample_period;
-    } else {
-        //Vector3::new(zero, zero, zero);
-        self.e_int.x = zero; self.e_int.y = zero; self.e_int.z = zero;
+        let e: Vector3<N> = accel.cross(&v) + mag.cross(&w);
+
+        // Error is sum of cross product between estimated direction and measured direction of fields
+        if self.ki > zero {
+            self.e_int += e * self.sample_period;
+        } else {
+            //Vector3::new(zero, zero, zero);
+            self.e_int.x = zero;
+            self.e_int.y = zero;
+            self.e_int.z = zero;
+        }
+
+        // Apply feedback terms
+        let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
+
+        // Compute rate of change of quaternion
+        let qDot = q * Quaternion::from_parts(zero, gyro) * half;
+
+        // Integrate to yield quaternion
+        self.quat = (q + qDot * self.sample_period).normalize();
+
+        Ok(&self.quat)
     }
-    
-    // Apply feedback terms
-    let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
 
-    // Compute rate of change of quaternion
-    let qDot = q * Quaternion::from_parts(zero, gyro) * half;
+    fn update_imu(
+        &mut self,
+        gyroscope: &Vector3<N>,
+        accelerometer: &Vector3<N>,
+    ) -> Result<&Quaternion<N>, &str> {
+        let q = self.quat;
 
-    // Integrate to yield quaternion
-    self.quat = (q + qDot * self.sample_period).normalize();
+        let zero: N = na::zero();
+        let two: N = na::convert(2.0);
+        let half: N = na::convert(0.5);
 
-    Ok(&self.quat)
-  }
+        // Normalize accelerometer measurement
+        let accel = match accelerometer.try_normalize(zero) {
+            Some(n) => n,
+            None => {
+                return Err("Accelerometer norm divided by zero.");
+            }
+        };
 
-  fn update_imu( &mut self, gyroscope: &Vector3<N>, accelerometer: &Vector3<N> ) -> Result<&Quaternion<N>, &str> {
-
-    let q = self.quat;
-    
-    let zero: N = na::zero();
-    let two: N = na::convert(2.0);
-    let half: N = na::convert(0.5);
-
-    // Normalize accelerometer measurement
-    let accel = match accelerometer.try_normalize(zero) {
-        Some(n) => n,
-        None => { return Err("Accelerometer norm divided by zero."); }
-    };
-
-    #[rustfmt::skip]
+        #[rustfmt::skip]
     let v = Vector3::new(
         two*( q[0]*q[2] - q[3]*q[1] ),
         two*( q[3]*q[0] + q[1]*q[2] ),
         q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
     );
 
-    let e = accel.cross(&v);
+        let e = accel.cross(&v);
 
-    // Error is sum of cross product between estimated direction and measured direction of fields
-    if self.ki > zero {
-        self.e_int += e * self.sample_period;
-    } else {
-        self.e_int.x = zero; self.e_int.y = zero; self.e_int.z = zero;
+        // Error is sum of cross product between estimated direction and measured direction of fields
+        if self.ki > zero {
+            self.e_int += e * self.sample_period;
+        } else {
+            self.e_int.x = zero;
+            self.e_int.y = zero;
+            self.e_int.z = zero;
+        }
+
+        // Apply feedback terms
+        let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
+
+        // Compute rate of change of quaternion
+        let qDot = q * Quaternion::from_parts(zero, gyro) * half;
+
+        // Integrate to yield quaternion
+        self.quat = (q + qDot * self.sample_period).normalize();
+
+        Ok(&self.quat)
     }
-
-    // Apply feedback terms
-    let gyro = *gyroscope + e * self.kp + self.e_int * self.ki;
-
-    // Compute rate of change of quaternion
-    let qDot = q * Quaternion::from_parts(zero, gyro) * half;
-
-    // Integrate to yield quaternion
-    self.quat = (q + qDot * self.sample_period).normalize();
-
-    Ok(&self.quat)
-  }
-
 }
-

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -144,18 +144,18 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
         let b = Quaternion::new(zero, Vector2::new(h[0], h[1]).norm(), zero, h[2]);
 
         #[rustfmt::skip]
-    let v = Vector3::new(
-        two*( q[0]*q[2] - q[3]*q[1] ),
-        two*( q[3]*q[0] + q[1]*q[2] ),
-        q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
-    );
+        let v = Vector3::new(
+            two*( q[0]*q[2] - q[3]*q[1] ),
+            two*( q[3]*q[0] + q[1]*q[2] ),
+            q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
+        );
 
         #[rustfmt::skip]
-    let w = Vector3::new(
-        two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]),
-        two*b[0]*(q[0]*q[1] - q[3]*q[2])        + two*b[2]*(q[3]*q[0] + q[1]*q[2]),
-        two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1])
-    );
+        let w = Vector3::new(
+            two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]),
+            two*b[0]*(q[0]*q[1] - q[3]*q[2])        + two*b[2]*(q[3]*q[0] + q[1]*q[2]),
+            two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1])
+        );
 
         let e: Vector3<N> = accel.cross(&v) + mag.cross(&w);
 
@@ -201,11 +201,11 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
         };
 
         #[rustfmt::skip]
-    let v = Vector3::new(
-        two*( q[0]*q[2] - q[3]*q[1] ),
-        two*( q[3]*q[0] + q[1]*q[2] ),
-        q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
-    );
+        let v = Vector3::new(
+            two*( q[0]*q[2] - q[3]*q[1] ),
+            two*( q[3]*q[0] + q[1]*q[2] ),
+            q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
+        );
 
         let e = accel.cross(&v);
 

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -134,16 +134,20 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
     // Reference direction of Earth's magnetic field (Quaternion should still be conj of q)
     let h = q * ( Quaternion::from_parts(zero, mag) * q.conjugate() );
     let b = Quaternion::new( zero, Vector2::new(h[0], h[1]).norm(), zero, h[2] );
- 
-    let v = Vector3::new(
-      two*( q[0]*q[2] - q[3]*q[1] ),
-      two*( q[3]*q[0] + q[1]*q[2] ),
-      q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2] );
 
+    #[rustfmt::skip]
+    let v = Vector3::new(
+        two*( q[0]*q[2] - q[3]*q[1] ),
+        two*( q[3]*q[0] + q[1]*q[2] ),
+        q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
+    );
+
+    #[rustfmt::skip]
     let w = Vector3::new(
         two*b[0]*(half - q[1]*q[1] - q[2]*q[2]) + two*b[2]*(q[0]*q[2] - q[3]*q[1]),
-        two*b[0]*(q[0]*q[1] - q[3]*q[2]) + two*b[2]*(q[3]*q[0] + q[1]*q[2]),
-        two*b[0]*(q[3]*q[1] + q[0]*q[2]) + two*b[2]*(half - q[0]*q[0] - q[1]*q[1]));
+        two*b[0]*(q[0]*q[1] - q[3]*q[2])        + two*b[2]*(q[3]*q[0] + q[1]*q[2]),
+        two*b[0]*(q[3]*q[1] + q[0]*q[2])        + two*b[2]*(half - q[0]*q[0] - q[1]*q[1])
+    );
 
     let e: Vector3<N> = accel.cross(&v) + mag.cross(&w);
     
@@ -181,10 +185,12 @@ impl<N: Real> Ahrs<N> for Mahony<N> {
         None => { return Err("Accelerometer norm divided by zero."); }
     };
 
+    #[rustfmt::skip]
     let v = Vector3::new(
-      two*( q[0]*q[2] - q[3]*q[1] ),
-      two*( q[3]*q[0] + q[1]*q[2] ),
-      q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2] );
+        two*( q[0]*q[2] - q[3]*q[1] ),
+        two*( q[3]*q[0] + q[1]*q[2] ),
+        q[3]*q[3] - q[0]*q[0] - q[1]*q[1] + q[2]*q[2]
+    );
 
     let e = accel.cross(&v);
 


### PR DESCRIPTION
Gives [im]mutable access to inner algorithm struct fields that aren't normally exposed. The exposed API is considered unstable for the time-being, but is nevertheless a useful feature.

Making all fields `pub` might be cleaner, but I personally prefer a defined API over unfettered access.

This PR also:
- Updates all deps to latest minor versions
- Formats code via `rustfmt`