### PR TITLE
Adding no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,25 @@ keywords = ["ahrs", "madgwick", "imu", "kalman", "accelerometer"]
 license = "GPL-3.0"
 
 [features]
-default = []
+default = [ "std" ]
+std = ["nalgebra/default", "alga/default", "rand/default"]
 field_access = []
 
 [lib]
 name = "ahrs"
 path = "src/lib.rs"
 
-[dependencies]
-nalgebra = "0.17"
-alga  = "0.8"
+[dependencies.nalgebra]
+version = "0.17"
+default-features = false
 
-[dev-dependencies]
-rand = "0.6"
-approx = "0.3"
+[dependencies.alga]
+version = "0.8"
+default-features = false
+
+[dev-dependencies.rand]
+version = "0.6"
+default-features = false
+
+[dev-dependencies.approx]
+version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! A collection of AHRS algorithms ported to Rust.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![crate_name = "ahrs"]
 
 extern crate nalgebra as na;


### PR DESCRIPTION
In response to #11, I was able to get the filter running on an STM32F4 microcontroller.