### PR TITLE
Cargo.toml: Remove rand std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "GPL-3.0"
 
 [features]
 default = [ "std" ]
-std = ["nalgebra/default", "alga/default", "rand/default"]
+std = ["nalgebra/default", "alga/default"]
 field_access = []
 
 [lib]


### PR DESCRIPTION
In order to fix the following error:
...depends on `ahrs`, with features: `rand` but `ahrs` does not have these features.
when using this package remove the "rand/default" feature from
std as it is only required as a dev dependency.

Signed-off-by: Alistair Francis <alistair@alistair23.me>