### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com)
+and this project adheres to [Semantic Versioning](http://semver.org).
+
+## [Unreleased]
+
+## [0.2.2] - 2020-04-19
+
+### Fixed
+- Remove reference to dev-dependency `rand` in non-dev builds.
+
+## [0.2.1] - 2019-10-19
+
+### Added
+- Add experimental feature `field_access` for access to filter parameters.
+- Add `no_std` support.
+
+[Unreleased]: https://github.com/jmagnuson/ahrs-rs/compare/v0.2.2...master
+[0.2.2]: https://github.com/jmagnuson/ahrs-rs/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/jmagnuson/ahrs-rs/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "ahrs"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 
 description = "A Rust port of Madgwick's AHRS algorithm"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add ahrs-rs to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ahrs = "0.2.0"
+ahrs = "0.2.2"
 ```
 
 Here's a simple example that updates the filter state with arbitrary sensor data:


### PR DESCRIPTION
Updating nalgebra would break compat, so releasing for now with #14 and then will bump to 0.3 with the nalgebra 0.21 update.