### PR TITLE
Update nalgebra to v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ### Changed
 - Update to 2018 edition rust.
+- Update `nalgebra` to v0.21.
 
 ## [0.2.2] - 2020-04-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 default = [ "std" ]
-std = ["nalgebra/default", "alga/default"]
+std = ["nalgebra/default", "simba/default", "num-traits/default"]
 field_access = []
 
 [lib]
@@ -24,15 +24,19 @@ name = "ahrs"
 harness = false
 
 [dependencies.nalgebra]
-version = "0.18"
+version = "0.21"
 default-features = false
 
-[dependencies.alga]
-version = "0.9"
+[dependencies.simba]
+version = "0.1"
+default-features = false
+
+[dependencies.num-traits]
+version = "0.2"
 default-features = false
 
 [dev-dependencies.rand]
-version = "0.6"
+version = "0.7"
 
 [dev-dependencies.approx]
 version = "0.3"

--- a/benches/ahrs.rs
+++ b/benches/ahrs.rs
@@ -1,5 +1,3 @@
-#![rustfmt::skip::macros(bench_ahrs)]
-
 use ahrs::{Ahrs, Madgwick, Mahony};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{self, thread_rng, Rng};

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -1,8 +1,8 @@
-use alga::general::RealField;
-use nalgebra::{Quaternion, Vector3};
+use nalgebra::{Quaternion, Scalar, Vector3};
+use simba::simd::SimdValue;
 
 /// Trait for implementing an AHRS filter.
-pub trait Ahrs<N: RealField> {
+pub trait Ahrs<N: Scalar + SimdValue> {
     /// Attempts to update the current state quaternion using 9dof IMU values, made up by `gyroscope`,
     /// `accelerometer`, and `magnetometer`.
     ///

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -1,18 +1,55 @@
 #![allow(non_snake_case)]
 
 use crate::ahrs::Ahrs;
-use alga::general::RealField;
-use nalgebra::{Matrix4, Matrix6, Quaternion, Vector2, Vector3, Vector4, Vector6};
+use core::hash;
+use nalgebra::{Matrix4, Matrix6, Quaternion, Scalar, Vector2, Vector3, Vector4, Vector6};
+use simba::simd::{SimdRealField, SimdValue};
 
 /// Madgwick AHRS implementation.
-#[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
-pub struct Madgwick<N: RealField> {
+#[derive(Debug)]
+pub struct Madgwick<N: Scalar + SimdValue> {
     /// Expected sampling period, in seconds.
     sample_period: N,
     /// Filter gain.
     beta: N,
     /// Filter state quaternion.
     pub quat: Quaternion<N>,
+}
+
+impl<N: SimdRealField + Eq> Eq for Madgwick<N> where N::Element: SimdRealField {}
+
+impl<N: SimdRealField> PartialEq for Madgwick<N>
+where
+    N::Element: SimdRealField,
+{
+    fn eq(&self, rhs: &Self) -> bool {
+        self.sample_period == rhs.sample_period && self.beta == rhs.beta && self.quat == rhs.quat
+    }
+}
+
+impl<N: SimdRealField + hash::Hash> hash::Hash for Madgwick<N> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.sample_period.hash(state);
+        self.beta.hash(state);
+        self.quat.hash(state);
+    }
+}
+
+impl<N: Scalar + Copy + SimdValue> Copy for Madgwick<N> {}
+
+impl<N: Scalar + SimdValue> Clone for Madgwick<N> {
+    #[inline]
+    fn clone(&self) -> Self {
+        let sample_period = self.sample_period.clone();
+        let beta = self.beta.clone();
+        let quat = self.quat.clone();
+
+        Madgwick {
+            sample_period,
+            beta,
+            quat,
+        }
+    }
 }
 
 impl Default for Madgwick<f64> {
@@ -34,7 +71,7 @@ impl Default for Madgwick<f64> {
     }
 }
 
-impl<N: RealField> Madgwick<N> {
+impl<N: Scalar + SimdValue + num_traits::One + num_traits::Zero> Madgwick<N> {
     /// Creates a new `Madgwick` AHRS instance with identity quaternion.
     ///
     /// # Arguments
@@ -91,7 +128,7 @@ impl<N: RealField> Madgwick<N> {
 }
 
 #[cfg(feature = "field_access")]
-impl<N: RealField> Madgwick<N> {
+impl<N: Scalar + SimdValue + Copy> Madgwick<N> {
     /// Expected sampling period, in seconds.
     pub fn sample_period(&self) -> N {
         self.sample_period
@@ -123,7 +160,7 @@ impl<N: RealField> Madgwick<N> {
     }
 }
 
-impl<N: RealField> Ahrs<N> for Madgwick<N> {
+impl<N: simba::scalar::RealField> Ahrs<N> for Madgwick<N> {
     fn update(
         &mut self,
         gyroscope: &Vector3<N>,

--- a/src/madgwick.rs
+++ b/src/madgwick.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![allow(clippy::many_single_char_names)]
 
 use crate::ahrs::Ahrs;
 use core::hash;
@@ -6,6 +7,15 @@ use nalgebra::{Matrix4, Matrix6, Quaternion, Scalar, Vector2, Vector3, Vector4, 
 use simba::simd::{SimdRealField, SimdValue};
 
 /// Madgwick AHRS implementation.
+///
+/// # Example
+/// ```
+/// # use ahrs::Madgwick;
+/// let mut ahrs = Madgwick::new(0.002390625f64, 0.1);
+/// println!("madgwick filter: {:?}", ahrs);
+///
+/// // Can now process IMU data using `Ahrs::update_imu`, etc.
+/// ```
 #[derive(Debug)]
 pub struct Madgwick<N: Scalar + SimdValue> {
     /// Expected sampling period, in seconds.
@@ -53,14 +63,20 @@ impl<N: Scalar + SimdValue> Clone for Madgwick<N> {
 }
 
 impl Default for Madgwick<f64> {
-    /// Creates a new `Madgwick` instance with default filter parameters:
+    /// Creates a new `Madgwick` instance with default filter parameters.
     ///
-    /// ```rust,ignore
-    /// Madgwick {
-    ///     sample_period: 1.0f64/256.0,
-    ///     beta: 0.1f64,
-    ///     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
-    /// }
+    /// ```
+    /// # use ahrs::Madgwick;
+    /// # use nalgebra::{Quaternion, Vector4};
+    /// dbg!(Madgwick::default());
+    ///
+    /// // prints (roughly):
+    /// //
+    /// // Madgwick {
+    /// //     sample_period: 1.0f64/256.0,
+    /// //     beta: 0.1f64,
+    /// //     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
+    /// // };
     /// ```
     fn default() -> Madgwick<f64> {
         Madgwick {
@@ -78,16 +94,6 @@ impl<N: Scalar + SimdValue + num_traits::One + num_traits::Zero> Madgwick<N> {
     ///
     /// * `sample_period` - The expected sensor sampling period in seconds.
     /// * `beta` - Filter gain.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use ahrs::Madgwick;
-    ///
-    /// fn main() {
-    ///     let ahrs = Madgwick::new(0.002390625f64, 0.1);
-    /// }
-    /// ```
     pub fn new(sample_period: N, beta: N) -> Self {
         Madgwick::new_with_quat(
             sample_period,
@@ -103,21 +109,6 @@ impl<N: Scalar + SimdValue + num_traits::One + num_traits::Zero> Madgwick<N> {
     /// * `sample_period` - The expected sensor sampling period in seconds.
     /// * `beta` - Filter gain.
     /// * `quat` - Existing filter state quaternion.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use ahrs::Madgwick;
-    /// use nalgebra::Quaternion;
-    ///
-    /// fn main() {
-    ///     let ahrs = Madgwick::new_with_quat(
-    ///         0.002390625f64,
-    ///         0.1,
-    ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
-    ///     );
-    /// }
-    /// ```
     pub fn new_with_quat(sample_period: N, beta: N, quat: Quaternion<N>) -> Self {
         Madgwick {
             sample_period,

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![allow(clippy::many_single_char_names)]
 
 use crate::ahrs::Ahrs;
 use core::hash;
@@ -6,6 +7,15 @@ use nalgebra::{Quaternion, Scalar, Vector2, Vector3};
 use simba::simd::{SimdRealField as RealField, SimdRealField, SimdValue};
 
 /// Mahony AHRS implementation.
+///
+/// # Example
+/// ```
+/// # use ahrs::Mahony;
+/// let mut ahrs = Mahony::new(0.002390625f64, 0.5, 0.0);
+/// println!("mahony filter: {:?}", ahrs);
+///
+/// // Can now process IMU data using `Ahrs::update_imu`, etc.
+/// ```
 #[derive(Debug)]
 pub struct Mahony<N: Scalar + SimdValue> {
     /// Expected sampling period, in seconds.
@@ -67,16 +77,22 @@ impl<N: Scalar + SimdValue> Clone for Mahony<N> {
 }
 
 impl Default for Mahony<f64> {
-    /// Creates a default `Mahony` AHRS instance with default filter parameters:
+    /// Creates a default `Mahony` AHRS instance with default filter parameters.
     ///
-    /// ```rust,ignore
-    /// Mahony {
-    ///     sample_period: 1.0f64/256.0,
-    ///     kp: 0.5f64,
-    ///     ki: 0.0f64,
-    ///     e_int: Vector3 { x: 0.0f64, y: 0.0, z: 0.0 },
-    ///     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
-    /// }
+    /// ```
+    /// # use ahrs::Mahony;
+    /// # use nalgebra::{Quaternion, Vector4};
+    /// dbg!(Mahony::default());
+    ///
+    /// // prints (roughly):
+    /// //
+    /// // Madgwick {
+    /// //     sample_period: 1.0f64/256.0,
+    /// //     kp: 0.5f64,
+    /// //     ki: 0.0f64,
+    /// //     e_int: Vector3 { x: 0.0f64, y: 0.0, z: 0.0 },
+    /// //     quat: Quaternion { w: 1.0f64, i: 0.0, j: 0.0, k: 0.0 }
+    /// // };
     /// ```
     fn default() -> Mahony<f64> {
         Mahony {
@@ -97,16 +113,6 @@ impl<N: RealField> Mahony<N> {
     /// * `sample_period` - The expected sensor sampling period in seconds.
     /// * `kp` - Proportional filter gain constant.
     /// * `ki` - Integral filter gain constant.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use ahrs::Mahony;
-    ///
-    /// fn main() {
-    ///     let ahrs = Mahony::new(0.002390625f64, 0.5, 0.0);
-    /// }
-    /// ```
     pub fn new(sample_period: N, kp: N, ki: N) -> Self {
         Mahony::new_with_quat(
             sample_period,
@@ -124,22 +130,6 @@ impl<N: RealField> Mahony<N> {
     /// * `kp` - Proportional filter gain constant.
     /// * `ki` - Integral filter gain constant.
     /// * `quat` - Existing filter state quaternion.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use ahrs::Mahony;
-    /// use nalgebra::Quaternion;
-    ///
-    /// fn main() {
-    ///     let ahrs = Mahony::new_with_quat(
-    ///         0.002390625f64,
-    ///         0.5,
-    ///         0.0,
-    ///         Quaternion::new(1.0, 0.0, 0.0, 0.0)
-    ///     );
-    /// }
-    /// ```
     pub fn new_with_quat(sample_period: N, kp: N, ki: N, quat: Quaternion<N>) -> Self {
         Mahony {
             sample_period,


### PR DESCRIPTION
I haven't gone too deeply to see if the trait bounds can be simplified, but after looking at what the underlying `nalgebra` types are doing, I'm pretty sure this is as concise as possible.

Should also bump minor version after this gets merged. And maybe rework the return `Err` type in `Ahrs` while I'm breaking stuff.