### PR TITLE
Store the quaternion as a UnitQuaternion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here's a simple example that updates the filter state with arbitrary sensor data
 
 ```rust
 use ahrs::{Ahrs, Madgwick};
-use nalgebra::{Vector3, Quaternion};
+use nalgebra::Vector3;
 use std::f64;
 
 fn main() {
@@ -33,16 +33,18 @@ fn main() {
     let magnetometer = Vector3::new(0.5, 0.6, 0.7);
     
     // Run inputs through AHRS filter (gyroscope must be radians/s)
-    let quat: &Quaternion<f64> = ahrs.update(
-        &(gyroscope * (f64::consts::PI/180.0)),
-        &accelerometer,
-        &magnetometer
-    ).unwrap();
-    
-    // Do something with the updated state quaternion
-    println!("{}", quat);
-}
+    let quat = ahrs
+        .update(
+            &(gyroscope * (f64::consts::PI / 180.0)),
+            &accelerometer,
+            &magnetometer,
+        )
+        .unwrap();
+    let (roll, pitch, yaw) = quat.euler_angles();
 
+    // Do something with the updated state quaternion
+    println!("pitch={}, roll={}, yaw={}", pitch, roll, yaw);
+}
 ```
 
 Crate [nalgebra](https://crates.io/crates/nalgebra) is also needed as a dependency for its algebraic types `Vector3` and `Quaternion`.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,26 @@
+use ahrs::{Ahrs, Madgwick};
+use nalgebra::Vector3;
+use std::f64;
+
+fn main() {
+    // Initialize filter with default values
+    let mut ahrs = Madgwick::default();
+
+    // Obtain sensor values from a source
+    let gyroscope = Vector3::new(60.1, 30.2, 20.3);
+    let accelerometer = Vector3::new(0.1, 0.2, 0.3);
+    let magnetometer = Vector3::new(0.5, 0.6, 0.7);
+
+    // Run inputs through AHRS filter (gyroscope must be radians/s)
+    let quat = ahrs
+        .update(
+            &(gyroscope * (f64::consts::PI / 180.0)),
+            &accelerometer,
+            &magnetometer,
+        )
+        .unwrap();
+    let (roll, pitch, yaw) = quat.euler_angles();
+
+    // Do something with the updated state quaternion
+    println!("pitch={}, roll={}, yaw={}", pitch, roll, yaw);
+}

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Quaternion, Scalar, Vector3};
+use nalgebra::{Scalar, UnitQuaternion, Vector3};
 use simba::simd::SimdValue;
 
 /// Trait for implementing an AHRS filter.
@@ -13,7 +13,7 @@ pub trait Ahrs<N: Scalar + SimdValue> {
         gyroscope: &Vector3<N>,
         accelerometer: &Vector3<N>,
         magnetometer: &Vector3<N>,
-    ) -> Result<&Quaternion<N>, &str>;
+    ) -> Result<&UnitQuaternion<N>, &str>;
 
     /// Attempts to update the current state quaternion using 6dof IMU values, made up by `gyroscope` &
     /// `accelerometer`.
@@ -24,5 +24,5 @@ pub trait Ahrs<N: Scalar + SimdValue> {
         &mut self,
         gyroscope: &Vector3<N>,
         accelerometer: &Vector3<N>,
-    ) -> Result<&Quaternion<N>, &str>;
+    ) -> Result<&UnitQuaternion<N>, &str>;
 }

--- a/src/mahony.rs
+++ b/src/mahony.rs
@@ -189,12 +189,12 @@ impl<N: Scalar + SimdValue + Copy> Mahony<N> {
     }
 
     /// Filter state quaternion.
-    pub fn quat(&self) -> Quaternion<N> {
+    pub fn quat(&self) -> UnitQuaternion<N> {
         self.quat
     }
 
     /// Mutable reference to filter state quaternion.
-    pub fn quat_mut(&mut self) -> &mut Quaternion<N> {
+    pub fn quat_mut(&mut self) -> &mut UnitQuaternion<N> {
         &mut self.quat
     }
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,6 +1,6 @@
 use ahrs::{Ahrs, Madgwick, Mahony};
 use approx::relative_eq;
-use nalgebra::{Quaternion, Vector3};
+use nalgebra::{Quaternion, UnitQuaternion, Vector3};
 use std::f64;
 
 // accel, gyro, mag values
@@ -60,12 +60,12 @@ fn test_update_imu_accel_zero() {
 
 #[test]
 fn test_madgwick_update() {
-    let start_quat = Quaternion::new(
+    let start_quat = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7252997863255918f64,
         0.6869689552600526,
         -0.04486780259245286,
         0.0008687666471569602,
-    );
+    ));
 
     let mut ahrs = Madgwick::default();
     ahrs.quat = start_quat;
@@ -76,12 +76,12 @@ fn test_madgwick_update() {
         .update(&(gyro * (f64::consts::PI / 180.0)), &accel, &mag)
         .unwrap();
 
-    let expected = Quaternion::new(
+    let expected = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7235467139148768,
         0.6888611247479446,
         -0.04412605927634125,
         0.001842413287185898,
-    );
+    ));
 
     let fail_message = format!(
         "quaternions did not match:\n\
@@ -95,12 +95,12 @@ fn test_madgwick_update() {
 
 #[test]
 fn test_madgwick_update_imu() {
-    let start_quat = Quaternion::new(
+    let start_quat = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7208922848226422,
         0.6922487447935516,
         -0.01829063767755937,
         0.02777483732249482,
-    );
+    ));
 
     let mut ahrs = Madgwick::default();
     ahrs.quat = start_quat;
@@ -111,12 +111,12 @@ fn test_madgwick_update_imu() {
         .update_imu(&(gyro * (f64::consts::PI / 180.0)), &accel)
         .unwrap();
 
-    let expected = Quaternion::new(
+    let expected = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7190919791549198,
         0.694101991692336,
         -0.01747200330433749,
         0.02870330545992814,
-    );
+    ));
 
     let fail_message = format!(
         "quaternions did not match:\n\
@@ -130,12 +130,12 @@ fn test_madgwick_update_imu() {
 
 #[test]
 fn test_mahony_update() {
-    let start_quat = Quaternion::new(
+    let start_quat = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7283043001825265,
         0.6845402884292506,
         -0.0251143587903031,
         0.0186201191024857,
-    );
+    ));
 
     let mut ahrs = Mahony::default();
     ahrs.quat = start_quat;
@@ -146,12 +146,12 @@ fn test_mahony_update() {
         .update(&(gyro * (f64::consts::PI / 180.0)), &accel, &mag)
         .unwrap();
 
-    let expected = Quaternion::new(
+    let expected = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7266895209095908,
         0.6862575490365720,
         -0.0243041556135902,
         0.0195505654756196,
-    );
+    ));
 
     let fail_message = format!(
         "quaternions did not match:\n\
@@ -165,12 +165,12 @@ fn test_mahony_update() {
 
 #[test]
 fn test_mahony_update_imu() {
-    let start_quat = Quaternion::new(
+    let start_quat = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7214290925667162,
         0.6917700035806650,
         -0.0169838640062460,
         0.0265683064531509,
-    );
+    ));
 
     let mut ahrs = Mahony::default();
     ahrs.quat = start_quat;
@@ -181,12 +181,12 @@ fn test_mahony_update_imu() {
         .update_imu(&(gyro * (f64::consts::PI / 180.0)), &accel)
         .unwrap();
 
-    let expected = Quaternion::new(
+    let expected = UnitQuaternion::new_unchecked(Quaternion::new(
         0.7197849027430218,
         0.6934642994058348,
         -0.0161568905395983,
         0.0274938924287729,
-    );
+    ));
 
     let fail_message = format!(
         "quaternions did not match:\n\


### PR DESCRIPTION
This allows us access to UnitQuaternion's `euler_angles()` method, and also more specifically declares the intent that the stored quaternion is normalized.