### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-10
+
+### Changed
+
+- Update `nalgebra` to v0.35.
+- Update `simba` to v0.10.
+- Update benchmark dependency `rand` to v0.10 and fix breaking changes.
+- Update benchmark dependency `criterion` to v0.8.
+
 ## [0.8.0] - 2025-09-15
 
 ### Changed
@@ -59,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add experimental feature `field_access` for access to filter parameters.
 - Add `no_std` support.
 
-[Unreleased]: https://github.com/jmagnuson/ahrs-rs/compare/v0.8.0...master
+[Unreleased]: https://github.com/jmagnuson/ahrs-rs/compare/v0.9.0...master
+[0.9.0]: https://github.com/jmagnuson/ahrs-rs/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jmagnuson/ahrs-rs/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jmagnuson/ahrs-rs/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jmagnuson/ahrs-rs/compare/v0.5.0...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ name = "ahrs"
 harness = false
 
 [dependencies.nalgebra]
-version = "0.34"
+version = "0.35"
 features = ["libm-force"]
 default-features = false
 
 [dependencies.simba]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.num-traits]
@@ -37,10 +37,10 @@ version = "0.2"
 default-features = false
 
 [dev-dependencies.rand]
-version = "0.9"
+version = "0.10"
 
 [dev-dependencies.approx]
 version = "0.5"
 
 [dev-dependencies.criterion]
-version = "0.7"
+version = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahrs"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 description = "A Rust port of Madgwick's AHRS algorithm"
 repository = "https://github.com/jmagnuson/ahrs-rs"

--- a/benches/ahrs.rs
+++ b/benches/ahrs.rs
@@ -1,6 +1,6 @@
 use ahrs::{Ahrs, Madgwick, Mahony};
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::{self, Rng, rng};
+use rand::{self, RngExt, rng};
 use std::hint::black_box;
 use std::stringify;
 


### PR DESCRIPTION
Hi there, I created this PR to catch up the latest nalgebra version.

This pull request updates several dependencies to their latest versions and makes a minor update to the `rand` import in the benchmark code. These changes help keep the project up-to-date and compatible with recent library improvements.

Dependency updates:

* Updated `nalgebra` to version `0.35` and `simba` to version `0.10` in `Cargo.toml` to use the latest versions and maintain compatibility.
* Updated development dependencies: `rand` to `0.10` and `criterion` to `0.8` in `Cargo.toml` for improved features and bug fixes.

Code maintenance:

* Updated the `rand` import in `benches/ahrs.rs` to use `RngExt` instead of `Rng` for compatibility with the latest `rand` crate.